### PR TITLE
feat: 

### DIFF
--- a/src/auth/auth.constant.ts
+++ b/src/auth/auth.constant.ts
@@ -9,8 +9,13 @@ export const COOKIE_SAMESITE = {
   STRICT: 'strict', // 동일 사이트 요청에만 쿠키 전송
   NONE: 'none', // 모든 요청에 쿠키 전송 (secure 필요)
 } as const;
+export const STRATEGY_TYPE = {
+  KAKAO: 'kakao', // 카카오 인증 전략
+} as const;
+// 인증 관련 타입 정의
 export type CookieSameSite =
   (typeof COOKIE_SAMESITE)[keyof typeof COOKIE_SAMESITE];
+export type StrategyType = (typeof STRATEGY_TYPE)[keyof typeof STRATEGY_TYPE];
 
 // 인증 관련 에러 메세지
 export const ERROR_MESSAGES = {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   COOKIE_SAMESITE,
   IS_SECURE,
   PROCESS_EXPIRATION_TIME,
+  STRATEGY_TYPE,
 } from '@gglk/auth/auth.constant';
 import { UserPayload } from '@gglk/auth/auth.interface';
 import { AuthService } from '@gglk/auth/auth.service';
@@ -15,12 +16,14 @@ export class AuthController {
 
   @Get('kakao')
   @UseGuards(KakaoGuard)
-  kakaoUnifiedHandler(@Req() req: Request, @Res() res: Response) {
+  async kakaoUnifiedHandler(@Req() req: Request, @Res() res: Response) {
     if (!req.user) return;
-    const user = req.user as UserPayload;
 
-    const payload: UserPayload = user;
-    const token = this.authService.generateToken(payload);
+    const user = req.user as UserPayload;
+    const token = await this.authService.generateToken(
+      user,
+      STRATEGY_TYPE.KAKAO,
+    );
 
     res.cookie('Authorization', token, {
       httpOnly: false,

--- a/src/auth/auth.interface.ts
+++ b/src/auth/auth.interface.ts
@@ -1,5 +1,5 @@
 export interface UserPayload {
   id: string;
   email?: string;
-  nickname?: string;
+  name?: string;
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,11 +4,13 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthController } from '@gglk/auth/auth.controller';
 import { AuthService } from '@gglk/auth/auth.service';
 import { KakaoStrategy } from '@gglk/auth/strategy/kakao.strategy';
+import { UserModule } from '@gglk/user/user.module';
 import { PROCESS_EXPIRATION_TIME } from './auth.constant';
 
 @Module({
   imports: [
     PassportModule,
+    UserModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET,
       signOptions: { expiresIn: PROCESS_EXPIRATION_TIME },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,13 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UserPayload } from '@gglk/auth/auth.interface';
+import { UserService } from '@gglk/user/user.service';
 
 @Injectable()
 export class AuthService {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly userService: UserService,
+  ) {}
 
-  generateToken(user: UserPayload): string {
-    const payload: UserPayload = user;
+  async generateToken(
+    userPayload: UserPayload,
+    strategyType: string,
+  ): Promise<string> {
+    const user = await this.userService.findOrCreateUser(
+      userPayload,
+      strategyType,
+    );
+
+    const payload: UserPayload = {
+      id: user.id,
+      name: user.name,
+    };
     return this.jwtService.sign(payload);
   }
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -15,4 +15,11 @@ export class User extends BaseEntity {
 
   @OneToMany(() => Evaluation, (evaluation) => evaluation.user)
   evaluations: Evaluation[];
+
+  // TODO : 추후 상의 필요
+  @Column({ default: 'kakao', nullable: true })
+  strategyType?: string;
+
+  @Column({ default: false })
+  providerId: string;
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
 import { UserController } from './user.controller';
 import { UserRepository } from './user.repository';
 import { UserService } from './user.service';
 
 @Module({
-  imports: [],
+  imports: [TypeOrmModule.forFeature([User])],
   controllers: [UserController],
   providers: [UserService, UserRepository],
   exports: [UserService],

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,7 +1,36 @@
 import { Injectable } from '@nestjs/common';
+import { UserPayload } from '@gglk/auth/auth.interface';
+import { User } from './entities/user.entity';
 import { UserRepository } from './user.repository';
 
 @Injectable()
 export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
+
+  async findOrCreateUser(
+    payload: UserPayload,
+    strategyType: string,
+  ): Promise<User> {
+    const existingUser = await this.userRepository.findOne({
+      where: { providerId: payload.id },
+    });
+    if (existingUser) {
+      return existingUser;
+    }
+
+    const newUser = this.userRepository.create({
+      name: payload.name ?? '',
+      joinedAt: new Date(),
+      isDeleted: false,
+      strategyType: strategyType,
+      providerId: payload.id,
+    });
+    return this.userRepository.save(newUser);
+  }
+
+  async findById(id: string): Promise<User | null> {
+    return this.userRepository.findOne({
+      where: { id, isDeleted: false },
+    });
+  }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#38 

### 📝 작업 내용

- User Entity 내에 2가지 속성이 추가되었어요.
  - strategyType: string, OAuth 인증 방법에 대한 값(ex. 카카오 인증이라면 'kakao'로 저장)
  - providerId : OAuth 인증 이후, provider가 반환하는 ID
- OAuth controller 인증 시, async로 받도록 했어요.
- User 모듈에서 repository를 사용할 수 있도록 설정했어요.(TypeOrmModule.forFeature) 

### 스크린샷 (선택)

https://github.com/user-attachments/assets/54fc0b7e-c457-4c26-8aef-20ab886ea90e

## 💬 리뷰 요구사항(선택)

1. userPayload는 현재 auth에 있습니다. user로 이관하는 것은 어떤 지 궁금합니다.
2. `User` Entity의 strategyType과 providerId가 불필요하진 않은 지, 더 나 은 방법은 없는 지에 대한 검토가 필요해보입니다.