### PR TITLE
fix: OAuth에서 인증 로직 일부를 프론트엔드로 역할 조정

### DIFF
--- a/libs/error-types/src/enum.ts
+++ b/libs/error-types/src/enum.ts
@@ -38,6 +38,7 @@ export const AuthModuleKey = {
   UNAUTHORIZED: 'G1001',
   INVALID_CREDENTIALS: 'G1002',
   FORBIDDEN_REQUEST: 'G1003',
+  KAKAO_OAUTH_ERROR: 'G1004',
 } as const;
 
 const AuthModuleError: Record<string, IErrorPayload> = {
@@ -52,6 +53,10 @@ const AuthModuleError: Record<string, IErrorPayload> = {
   [AuthModuleKey.FORBIDDEN_REQUEST]: {
     errorMessage: 'FORBIDDEN_REQUEST',
     statusCode: HttpStatus.FORBIDDEN,
+  },
+  [AuthModuleKey.KAKAO_OAUTH_ERROR]: {
+    errorMessage: 'ERROR_WHILE_AUTHORIZING_TO_KAKAO_OAUTH',
+    statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
   },
 } as const;
 
@@ -77,7 +82,7 @@ export const PictureModuleKey = {
   NCP_NETWORK_ERROR: 'G3002',
 } as const;
 
-const PictureModuleError = {
+const PictureModuleError: Record<string, IErrorPayload> = {
   [PictureModuleKey.NCP_NETWORK_ERROR]: {
     errorMessage: 'NCP_NETWORK_ERROR',
     statusCode: HttpStatus.INTERNAL_SERVER_ERROR,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nestjs/swagger": "^11.1.6",
     "@nestjs/typeorm": "^11.0.0",
     "aws-sdk": "^2.1692.0",
+    "axios": "^1.10.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "dotenv": "^16.5.0",
@@ -51,8 +52,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.22",
-    "zod": "^3.25.30",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.25.30"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   STRATEGY_TYPE,
 } from '@gglk/auth/auth.constant';
 import { AuthService } from '@gglk/auth/auth.service';
+import { KakakoLoginRequestDto } from './dto';
 
 @Controller('auth')
 export class AuthController {
@@ -30,12 +31,15 @@ export class AuthController {
 
   @Post('kakao/login')
   async kakaoLoginHandler(
-    @Body() body: { access_token: string },
+    @Body() body: KakakoLoginRequestDto,
     @Res() res: Response,
   ) {
-    const kakaoUser = await this.authService.getKakaoUserByAccessToken(
-      body.access_token,
+    const access_token = await this.authService.getKakaoUserAccessToken(
+      body.code,
     );
+
+    const kakaoUser =
+      await this.authService.getKakaoUserByAccessToken(access_token);
 
     const token = await this.authService.generateToken(
       kakaoUser,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -13,11 +13,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Get('kakao')
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async kakaoRedirectHandler(
-    @Req() request: Request,
-    @Res() response: Response,
-  ) {
+  kakaoRedirectHandler(@Req() request: Request, @Res() response: Response) {
     const state = request.query.state as string;
     const code = request.query.code as string;
     const redirectUrl = decodeURIComponent(state);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -36,6 +36,7 @@ export class AuthController {
   ) {
     const access_token = await this.authService.getKakaoUserAccessToken(
       body.code,
+      body.redirectUri,
     );
 
     const kakaoUser =

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,54 +1,28 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, Res } from '@nestjs/common';
 import { Request, Response } from 'express';
 import {
   COOKIE_SAMESITE,
-  ERROR_MESSAGES,
   IS_SECURE,
   PROCESS_EXPIRATION_TIME,
-  REDIRECT_WHITELIST,
   STRATEGY_TYPE,
 } from '@gglk/auth/auth.constant';
-import { UserPayload } from '@gglk/auth/auth.interface';
 import { AuthService } from '@gglk/auth/auth.service';
-import { KakaoGuard } from '@gglk/auth/guard/kakao.guard';
-import { BaseException } from '@gglk/common/exception/base.exception';
 
-function validateRedirectUrl(url?: string): void {
-  if (!url) {
-    throw new BaseException(400, ERROR_MESSAGES.REDIRECT_URL.NOT_EXIST);
-  }
-
-  const isAllowed = REDIRECT_WHITELIST.some((allowed) =>
-    url.startsWith(allowed),
-  );
-
-  if (!isAllowed) {
-    throw new BaseException(400, ERROR_MESSAGES.REDIRECT_URL.NO_ALLOWED);
-  }
-}
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Get('kakao')
-  @UseGuards(KakaoGuard)
-  async kakaoUnifiedHandler(
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async kakaoRedirectHandler(
     @Req() request: Request,
     @Res() response: Response,
   ) {
-    if (!request.user) return;
-
     const state = request.query.state as string;
+    const code = request.query.code as string;
     const redirectUrl = decodeURIComponent(state);
-    validateRedirectUrl(redirectUrl);
 
-    const user = request.user as UserPayload;
-    const token = await this.authService.generateToken(
-      user,
-      STRATEGY_TYPE.KAKAO,
-    );
-
-    response.cookie('Authorization', token, {
+    response.cookie('code', code, {
       httpOnly: false,
       secure: IS_SECURE,
       sameSite: COOKIE_SAMESITE.LAX,
@@ -56,5 +30,22 @@ export class AuthController {
     });
 
     response.redirect(redirectUrl);
+  }
+
+  @Post('kakao/login')
+  async kakaoLoginHandler(
+    @Body() body: { access_token: string },
+    @Res() res: Response,
+  ) {
+    const kakaoUser = await this.authService.getKakaoUserByAccessToken(
+      body.access_token,
+    );
+
+    const token = await this.authService.generateToken(
+      kakaoUser,
+      STRATEGY_TYPE.KAKAO,
+    );
+
+    res.json({ token });
   }
 }

--- a/src/auth/auth.interface.ts
+++ b/src/auth/auth.interface.ts
@@ -8,5 +8,6 @@ export interface KakaoUserResponse {
   id: number | string;
   properties?: {
     nickname?: string;
+    email?: string;
   };
 }

--- a/src/auth/auth.interface.ts
+++ b/src/auth/auth.interface.ts
@@ -3,3 +3,10 @@ export interface UserPayload {
   email?: string;
   name?: string;
 }
+
+export interface KakaoUserResponse {
+  id: number | string;
+  properties?: {
+    nickname?: string;
+  };
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,32 +1,76 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { KakaoUserResponse, UserPayload } from '@gglk/auth/auth.interface';
 import { UserService } from '@gglk/user/user.service';
+import { KakaoOauthException } from './exceptions';
 
 @Injectable()
 export class AuthService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly userService: UserService,
+    private readonly configService: ConfigService,
   ) {}
 
-  async getKakaoUserByAccessToken(accessToken: string): Promise<UserPayload> {
-    const userRes = await axios.get<KakaoUserResponse>(
-      'https://kapi.kakao.com/v2/user/me',
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
+  async getKakaoUserAccessToken(code: string) {
+    try {
+      const response = await axios.post(
+        'https://kauth.kakao.com/oauth/token',
+        {
+          grant_type: 'authorization_code',
+          client_id: this.configService.get<string>('KAKAO_CLIENT_ID'),
+          code: code,
         },
-      },
-    );
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+          },
+        },
+      );
+      const { access_token }: { access_token: string; [k: string]: unknown } =
+        response.data;
+      return access_token;
+    } catch (e) {
+      if (e instanceof AxiosError) {
+        console.error(
+          'Error while making authentication to Kakao - Get bearer token',
+        );
+        throw new KakaoOauthException();
+      } else {
+        throw e;
+      }
+    }
+  }
 
-    const kakaoUser = userRes.data;
+  async getKakaoUserByAccessToken(accessToken: string) {
+    try {
+      const userRes = await axios.get<KakaoUserResponse>(
+        'https://kapi.kakao.com/v2/user/me',
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
 
-    return {
-      id: kakaoUser.id.toString(),
-      name: kakaoUser.properties?.nickname,
-    };
+      const kakaoUser = userRes.data;
+      console.log(kakaoUser);
+      return {
+        id: kakaoUser.id.toString(),
+        name: kakaoUser.properties?.nickname,
+      };
+    } catch (e) {
+      if (e instanceof AxiosError) {
+        console.error(
+          'Error while making authentication to Kakao - Get user information',
+        );
+        throw new KakaoOauthException();
+      } else {
+        throw e;
+      }
+    }
   }
 
   // 내부 서비스 전용 JWT 토큰 발급

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -14,15 +14,20 @@ export class AuthService {
     private readonly configService: ConfigService,
   ) {}
 
-  async getKakaoUserAccessToken(code: string) {
+  async getKakaoUserAccessToken(code: string, redirectUri: string) {
     try {
+      const data = new URLSearchParams();
+      data.append('grant_type', 'authorization_code');
+      data.append(
+        'client_id',
+        this.configService.get<string>('KAKAO_CLIENT_ID')!,
+      );
+      data.append('code', code);
+      data.append('redirect_uri', redirectUri);
+
       const response = await axios.post(
         'https://kauth.kakao.com/oauth/token',
-        {
-          grant_type: 'authorization_code',
-          client_id: this.configService.get<string>('KAKAO_CLIENT_ID'),
-          code: code,
-        },
+        data,
         {
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import axios from 'axios';
-import { UserPayload } from '@gglk/auth/auth.interface';
+import { KakaoUserResponse, UserPayload } from '@gglk/auth/auth.interface';
 import { UserService } from '@gglk/user/user.service';
 
 @Injectable()
@@ -12,20 +12,20 @@ export class AuthService {
   ) {}
 
   async getKakaoUserByAccessToken(accessToken: string): Promise<UserPayload> {
-    const userRes = await axios.get('https://kapi.kakao.com/v2/user/me', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
+    const userRes = await axios.get<KakaoUserResponse>(
+      'https://kapi.kakao.com/v2/user/me',
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
       },
-    });
+    );
 
-    const kakaoUser = userRes.data as {
-      id: number | string;
-      properties?: { nickname?: string };
-    };
+    const kakaoUser = userRes.data;
 
     return {
       id: kakaoUser.id.toString(),
-      name: kakaoUser.properties?.nickname ?? 'unknown',
+      name: kakaoUser.properties?.nickname,
     };
   }
 

--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './kakao-login-request.dto';

--- a/src/auth/dto/kakao-login-request.dto.ts
+++ b/src/auth/dto/kakao-login-request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class KakakoLoginRequestDto {
+  @ApiProperty({
+    required: true,
+    description: 'Kakao Oauth Code',
+  })
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+}

--- a/src/auth/dto/kakao-login-request.dto.ts
+++ b/src/auth/dto/kakao-login-request.dto.ts
@@ -9,4 +9,12 @@ export class KakakoLoginRequestDto {
   @IsString()
   @IsNotEmpty()
   code: string;
+
+  @ApiProperty({
+    required: true,
+    description: 'Kakao Oauth Code redirected source URI',
+  })
+  @IsString() // IsUrl이 의도한대로 동작하지 않는듯해서 일단 IsString으로 대체
+  @IsNotEmpty()
+  redirectUri: string;
 }

--- a/src/auth/exceptions/index.ts
+++ b/src/auth/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './kakao-oauth.exception';

--- a/src/auth/exceptions/kakao-oauth.exception.ts
+++ b/src/auth/exceptions/kakao-oauth.exception.ts
@@ -1,0 +1,12 @@
+import { AuthModuleKey, ModuleErrors } from 'error-types';
+import { BaseException } from '@gglk/common';
+
+export class KakaoOauthException extends BaseException {
+  constructor() {
+    super(
+      ModuleErrors[AuthModuleKey.KAKAO_OAUTH_ERROR].statusCode,
+      ModuleErrors[AuthModuleKey.KAKAO_OAUTH_ERROR].errorMessage,
+      AuthModuleKey.KAKAO_OAUTH_ERROR,
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,15 @@ aws-sdk@^2.1692.0:
     uuid "8.0.0"
     xml2js "0.6.2"
 
+axios@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
+  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 b4a@^1.6.4:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.7.tgz#a99587d4ebbfbd5a6e3b21bdb5d5fa385767abe4"
@@ -3471,6 +3480,11 @@ flatted@^3.2.9:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -5602,6 +5616,11 @@ proxy-addr@^2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@1.3.2:
   version "1.3.2"


### PR DESCRIPTION
> 오늘은 피곤해서 일단 내일 자세히 적겠습니다...

## #️⃣ 연관된 이슈

resolve #46

<br>

### 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- axios를 설치하였어요.
- Kakao 관련 strategy와 guard를 사용하지 않고 있어요.
- OAuth 관련 url를 분리하였어요.

<br>

### 스크린샷 (선택)

<img width="805" alt="image" src="https://github.com/user-attachments/assets/6bd93b21-8dc7-43ab-926d-b62d66d0b812" />

![image](https://github.com/user-attachments/assets/089fde53-d1d4-49d6-8319-33ed1233ec48)


https://github.com/user-attachments/assets/d016fe27-0f1c-4b81-8d80-d64d0b5565b6

<br>

## 💬 리뷰 요구사항(선택)

### 1. axios를 auth.service.ts에서 호출하고 있습니다.

- "카카오 정보"를 가져와서 "DB"에 일부 저장하는 구조입니다.
- 이때 "카카오 정보"를 가져오는 작업은 kakao server에서 행하는 것인데, 이를 분리하는 것은 어떤지 궁금합니다.

#### 예상 의견

1. 그대로 두자 : axios 호출도 일종의 비즈니스 로직이다.
2. 분리하자 : 외부 api 호출은 비즈니스 로직에 해당하지 않는다. infrastructure나 api 등으로 책임 분리하자.

<br>

## 📚 참고할만한 자료(선택)

https://www.notion.so/Kakao-OAuth-API-21abee7f5996805094f9c3063ec6f2f5?source=copy_link



